### PR TITLE
test: remove redundant version check from integration tests

### DIFF
--- a/nix/vm/test.nix
+++ b/nix/vm/test.nix
@@ -690,12 +690,6 @@ pkgs.testers.nixosTest {
     machine.fail("su - vogix -c 'vogix theme nonexistent'")
     print("✓ Non-existent theme rejected")
 
-    print("\n=== Test 14: Version Check ===")
-    output = machine.succeed("su - vogix -c 'vogix --version'")
-    assert "vogix16" in output or "0.1.0" in output
-    print("✓ Version command works")
-    print(f"Version: {output}")
-
     print("\n" + "="*60)
     print("🎉 ALL TESTS PASSED!")
     print("="*60)


### PR DESCRIPTION
## Summary

Removes the redundant version check test (Test 14) from the integration test suite.

## Rationale

The version test was:
- **Redundant**: Test 1 already verifies the binary works via `vogix list`, and many other tests successfully execute the binary
- **Brittle**: Hardcoded version strings (`"vogix16"`, `"0.1.0"`) caused test failures when versions changed
- **Low value**: Checking if `--version` works doesn't add meaningful coverage beyond binary existence tests

## Changes

- Removed Test 14 (Version Check) from `nix/vm/test.nix`
- Test suite still validates binary installation and functionality through other tests

This simplifies maintenance and eliminates version-dependent test failures.