### PR TITLE
feat(app): add ripgrep theme support

### DIFF
--- a/nix/modules/applications/ripgrep.nix
+++ b/nix/modules/applications/ripgrep.nix
@@ -1,0 +1,50 @@
+{ lib }:
+
+# Helper function to generate ripgrep color configuration from semantic colors
+# Returns ripgrep config file content (for use in ~/.ripgreprc or RIPGREP_CONFIG_PATH)
+#
+# Ripgrep color format: --colors='type:attribute:value'
+# - type: path, line, column, match, highlight
+# - attribute: fg, bg, style
+# - value: RGB hex (0xRR,0xGG,0xBB) or color name
+#
+# Vogix16 Philosophy for ripgrep:
+# - Monochromatic for structure (path, line, column)
+# - Semantic colors ONLY for matches/highlights (what user needs to find)
+colors: let
+  # Helper to convert hex color to ripgrep RGB format
+  # Input: "#RRGGBB" -> Output: "0xRR,0xGG,0xBB"
+  hexToRgb = hex: let
+    # Remove # prefix if present
+    clean = lib.removePrefix "#" hex;
+    # Extract RGB components
+    r = builtins.substring 0 2 clean;
+    g = builtins.substring 2 2 clean;
+    b = builtins.substring 4 2 clean;
+  in "0x${r},0x${g},0x${b}";
+
+in ''
+  # Vogix16 theme for ripgrep
+  # Minimalist design: monochromatic structure, semantic highlights
+
+  # Structure elements - monochromatic (no semantic meaning)
+  # Path: file names and paths shown in output
+  --colors=path:fg:${hexToRgb colors.foreground-text}
+
+  # Line numbers: structural information
+  --colors=line:fg:${hexToRgb colors.foreground-comment}
+  --colors=line:style:bold
+
+  # Column numbers: structural information
+  --colors=column:fg:${hexToRgb colors.foreground-comment}
+
+  # Semantic elements - functional colors (information user needs)
+  # Match: the actual search match - PRIMARY semantic element
+  # User NEEDS to see what matched their search query
+  --colors=match:fg:${hexToRgb colors.active}
+  --colors=match:style:bold
+
+  # Highlight: context matches or secondary highlights
+  # Used for additional context around matches
+  --colors=highlight:fg:${hexToRgb colors.highlight}
+''

--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -29,6 +29,7 @@ let
     alacritty = "colors.toml";
     btop = "themes/vogix.theme";
     console = "palette";  # Binary palette file for setvtrgb
+    ripgrep = "ripgreprc";  # Config file for RIPGREP_CONFIG_PATH
     shell-colors = "colors.sh";
     ls-colors = "dircolors";
   }.${app} or "config";
@@ -440,6 +441,11 @@ MANIFEST_EOF
       Install = {
         WantedBy = [ "default.target" ];  # Run at user login
       };
+    };
+
+    # Set ripgrep config path environment variable
+    home.sessionVariables = mkIf (builtins.elem "ripgrep" themedApps) {
+      RIPGREP_CONFIG_PATH = "${config.xdg.configHome}/ripgrep/ripgreprc";
     };
 
     # Automatically source shell colors in bash (if shell-colors and ls-colors are auto-detected)


### PR DESCRIPTION
## Summary
Add Vogix16 theme configuration for ripgrep (grep alternative).

## Implementation
- Created `ripgrep.nix` generator with semantic color mapping
- Monochromatic colors for structure (path, line numbers, columns)
- Semantic colors for matches/highlights (active, highlight)  
- Outputs `ripgreprc` format with `--colors` flags
- RGB hex format (`0xRR,0xGG,0xBB`) for true color support

## Integration  
- Auto-discovered by home-manager module
- Sets `RIPGREP_CONFIG_PATH` environment variable
- Symlinks config to `~/.config/ripgrep/ripgreprc`

## Theme Design (Vogix16 Principles)
**Structure (Monochromatic):**
- Paths: `foreground-text`
- Line numbers: `foreground-comment` + bold
- Column numbers: `foreground-comment`

**Semantic (Functional):**
- Matches: `active` + bold (PRIMARY - user needs to see what matched)
- Highlights: `highlight` (context around matches)

No decorative colors - only functional information the user needs.

## Test Plan
- [x] Generator tested with sample colors
- [x] Config format validated against ripgrep documentation
- [x] Environment variable integration added to home-manager

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)