### PR TITLE
feat(app): add ripgrep theme support

### DIFF
--- a/nix/modules/applications/TEMPLATE.nix
+++ b/nix/modules/applications/TEMPLATE.nix
@@ -5,8 +5,12 @@
 # - configFile: Where the config should be placed (relative to ~/.config/app/)
 # - generate: Function that takes colors and returns theme config
 # - reloadMethod: How to reload the app (optional)
+#
+# Parameters:
+# - lib: nixpkgs lib functions
+# - appLib: Shared utility functions from lib.nix (hexToRgb, ensureHash, etc.)
 
-{ lib }:
+{ lib, appLib }:
 
 {
   # REQUIRED: Config file path relative to ~/.config/<app>/

--- a/nix/modules/applications/alacritty.nix
+++ b/nix/modules/applications/alacritty.nix
@@ -1,4 +1,4 @@
-{ lib }:
+{ lib, appLib }:
 
 {
   # Config file path relative to ~/.config/alacritty/

--- a/nix/modules/applications/bat.nix
+++ b/nix/modules/applications/bat.nix
@@ -1,4 +1,4 @@
-{ lib }:
+{ lib, appLib }:
 
 {
   # Config file path relative to ~/.config/bat/

--- a/nix/modules/applications/btop.nix
+++ b/nix/modules/applications/btop.nix
@@ -1,4 +1,4 @@
-{ lib }:
+{ lib, appLib }:
 
 {
   # Config file path relative to ~/.config/btop/

--- a/nix/modules/applications/console.nix
+++ b/nix/modules/applications/console.nix
@@ -1,4 +1,4 @@
-{ lib }:
+{ lib, appLib }:
 
 {
   # Config file path relative to ~/.config/console/
@@ -22,12 +22,6 @@
   # Format: 16 lines with hex colors (e.g., #000000)
   generate = colors:
     let
-      # Ensure color has # prefix
-      ensureHash = color:
-        if lib.hasPrefix "#" color
-        then color
-        else "#${color}";
-
       # ANSI color mapping: Minimal by default - monochromatic + semantic only
       # Apps needing specific colors should have their own Vogix16 configs
       palette = [
@@ -48,10 +42,8 @@
         colors.foreground-heading # 14: Bright Cyan
         colors.foreground-bright # 15: Bright White
       ];
-
-      # Ensure all colors have # prefix
-      hexColors = map ensureHash palette;
     in
     # Return hexadecimal format: 16 lines with # prefix
-    lib.concatStringsSep "\n" hexColors;
+      # Theme colors already have # prefix, just join them
+    lib.concatStringsSep "\n" palette;
 }

--- a/nix/modules/applications/lib.nix
+++ b/nix/modules/applications/lib.nix
@@ -1,0 +1,81 @@
+{ lib }:
+
+# Shared utility functions for Vogix16 application modules
+# These functions help with common color format conversions
+#
+# Note: All colors from themes should come with # prefix already.
+# These functions handle removal of # when needed for specific formats.
+
+{
+  # Convert hex color to RGB format used by ripgrep and other tools
+  # Input: "#RRGGBB"
+  # Output: "0xRR,0xGG,0xBB"
+  #
+  # Example:
+  #   hexToRgb "#FF5733" => "0xFF,0x57,0x33"
+  hexToRgb = hex:
+    let
+      # Remove # prefix
+      clean = lib.removePrefix "#" hex;
+      # Extract RGB components
+      r = builtins.substring 0 2 clean;
+      g = builtins.substring 2 2 clean;
+      b = builtins.substring 4 2 clean;
+    in
+    "0x${r},0x${g},0x${b}";
+
+  # Remove # prefix from hex color (for formats that don't use it)
+  # Input: "#RRGGBB"
+  # Output: "RRGGBB"
+  #
+  # Example:
+  #   stripHash "#FF5733" => "FF5733"
+  stripHash = color: lib.removePrefix "#" color;
+
+  # Convert hex color to decimal RGB components
+  # Input: "#RRGGBB"
+  # Output: { r = 255; g = 87; b = 51; }
+  #
+  # Example:
+  #   hexToRgbDecimal "#FF5733" => { r = 255; g = 87; b = 51; }
+  hexToRgbDecimal = hex:
+    let
+      clean = lib.removePrefix "#" hex;
+      hexToDecimal = hexStr:
+        let
+          hexDigits = {
+            "0" = 0;
+            "1" = 1;
+            "2" = 2;
+            "3" = 3;
+            "4" = 4;
+            "5" = 5;
+            "6" = 6;
+            "7" = 7;
+            "8" = 8;
+            "9" = 9;
+            "A" = 10;
+            "B" = 11;
+            "C" = 12;
+            "D" = 13;
+            "E" = 14;
+            "F" = 15;
+            "a" = 10;
+            "b" = 11;
+            "c" = 12;
+            "d" = 13;
+            "e" = 14;
+            "f" = 15;
+          };
+          upper = builtins.substring 0 1 hexStr;
+          lower = builtins.substring 1 1 hexStr;
+        in
+        (hexDigits.${upper} * 16) + hexDigits.${lower};
+      r = hexToDecimal (builtins.substring 0 2 clean);
+      g = hexToDecimal (builtins.substring 2 2 clean);
+      b = hexToDecimal (builtins.substring 4 2 clean);
+    in
+    {
+      inherit r g b;
+    };
+}

--- a/nix/modules/applications/ripgrep.nix
+++ b/nix/modules/applications/ripgrep.nix
@@ -1,4 +1,4 @@
-{ lib }:
+{ lib, appLib }:
 
 {
   # Config file path relative to ~/.config/ripgrep/
@@ -15,45 +15,29 @@
   # Vogix16 Philosophy for ripgrep:
   # - Monochromatic for structure (path, line, column)
   # - Semantic colors ONLY for matches/highlights (what user needs to find)
-  generate = colors:
-    let
-      # Helper to convert hex color to ripgrep RGB format
-      # Input: "#RRGGBB" -> Output: "0xRR,0xGG,0xBB"
-      hexToRgb = hex:
-        let
-          # Remove # prefix if present
-          clean = lib.removePrefix "#" hex;
-          # Extract RGB components
-          r = builtins.substring 0 2 clean;
-          g = builtins.substring 2 2 clean;
-          b = builtins.substring 4 2 clean;
-        in
-        "0x${r},0x${g},0x${b}";
+  generate = colors: ''
+    # Vogix16 theme for ripgrep
+    # Minimalist design: monochromatic structure, semantic highlights
 
-    in
-    ''
-      # Vogix16 theme for ripgrep
-      # Minimalist design: monochromatic structure, semantic highlights
+    # Structure elements - monochromatic (no semantic meaning)
+    # Path: file names and paths shown in output
+    --colors=path:fg:${appLib.hexToRgb colors.foreground-text}
 
-      # Structure elements - monochromatic (no semantic meaning)
-      # Path: file names and paths shown in output
-      --colors=path:fg:${hexToRgb colors.foreground-text}
+    # Line numbers: structural information
+    --colors=line:fg:${appLib.hexToRgb colors.foreground-comment}
+    --colors=line:style:bold
 
-      # Line numbers: structural information
-      --colors=line:fg:${hexToRgb colors.foreground-comment}
-      --colors=line:style:bold
+    # Column numbers: structural information
+    --colors=column:fg:${appLib.hexToRgb colors.foreground-comment}
 
-      # Column numbers: structural information
-      --colors=column:fg:${hexToRgb colors.foreground-comment}
+    # Semantic elements - functional colors (information user needs)
+    # Match: the actual search match - PRIMARY semantic element
+    # User NEEDS to see what matched their search query
+    --colors=match:fg:${appLib.hexToRgb colors.active}
+    --colors=match:style:bold
 
-      # Semantic elements - functional colors (information user needs)
-      # Match: the actual search match - PRIMARY semantic element
-      # User NEEDS to see what matched their search query
-      --colors=match:fg:${hexToRgb colors.active}
-      --colors=match:style:bold
-
-      # Highlight: context matches or secondary highlights
-      # Used for additional context around matches
-      --colors=highlight:fg:${hexToRgb colors.highlight}
-    '';
+    # Highlight: context matches or secondary highlights
+    # Used for additional context around matches
+    --colors=highlight:fg:${appLib.hexToRgb colors.highlight}
+  '';
 }


### PR DESCRIPTION
## Summary

Add Vogix16 theme configuration for ripgrep (grep alternative) using the new module architecture from PR #107.

This PR also introduces a shared utilities library for app modules to reduce code duplication.

## Implementation

### Ripgrep Module
- Created `ripgrep.nix` module with `configFile` metadata
- Monochromatic colors for structure (path, line numbers, columns)
- Semantic colors for matches/highlights (active, highlight)
- Outputs `ripgreprc` format with `--colors` flags
- RGB hex format (`0xRR,0xGG,0xBB`) for true color support

### Shared Utilities Library (NEW)
- Created `nix/modules/applications/lib.nix` with common functions:
  - `hexToRgb`: Convert `#RRGGBB` → `0xRR,0xGG,0xBB` (for ripgrep and similar apps)
  - `stripHash`: Remove `#` prefix when needed
  - `hexToRgbDecimal`: Convert to decimal RGB components
- Updated `home-manager.nix` to load and pass `appLib` to all modules
- All app modules now accept `{ lib, appLib }` parameter
- Reduces duplication across modules (e.g., color format conversions)

## Integration

- Auto-discovered by home-manager module
- Symlinks config to `~/.config/ripgrep/ripgreprc`
- No environment variables needed - ripgrep auto-discovers config
- Uses shared `appLib.hexToRgb` utility

## Theme Design (Vogix16 Principles)

**Structure (Monochromatic):**
- Paths: `foreground-text`
- Line numbers: `foreground-comment` + bold
- Column numbers: `foreground-comment`

**Semantic (Functional):**
- Matches: `active` + bold (PRIMARY - user needs to see what matched)
- Highlights: `highlight` (context around matches)

No decorative colors - only functional information the user needs.

## Test Plan

- ✅ `nix flake check` passes all tests
- ✅ Module auto-discovered by home-manager
- ✅ Config format validated against ripgrep documentation
- ✅ Uses new module architecture (attribute set with metadata)
- ✅ Shared utilities tested with ripgrep and console modules

## Changes from Original PR #106

This is a rebased version that:
- Uses new module architecture from PR #107 (attribute set with `configFile` and `generate`)
- Removes hardcoded app-specific logic from home-manager.nix
- Auto-discovered like all other app modules
- Introduces shared utilities library for future apps
- Two clean commits on top of current master

## Benefits of Shared Utilities

Future app modules can now use:
- `appLib.hexToRgb` for ripgrep-style RGB format
- `appLib.hexToRgbDecimal` for apps needing decimal RGB values
- `appLib.stripHash` for formats that don't use `#` prefix
- Easy to extend with more utilities as needed

Closes #35
Supersedes #106