### PR TITLE
Bootstrap devenv in .envrc if missing

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,12 +1,25 @@
 #!/usr/bin/env bash
-
 export DIRENV_WARN_TIMEOUT=20s
 
-eval "$(devenv direnvrc)"
+# Bootstrap devenv if it's not already available.
+if ! command -v devenv >/dev/null 2>&1; then
+  if ! command -v nix >/dev/null 2>&1; then
+    echo "error: devenv not found, and nix is not installed. Install Nix or provide devenv on PATH." >&2
+    exit 1
+  fi
 
-# `use devenv` supports the same options as the `devenv shell` command.
-#
-# To silence all output, use `--quiet`.
-#
-# Example usage: use devenv --quiet --impure --option services.postgres.enable:bool true
+  mkdir -p .direnv
+
+  # Cache the built devenv in .direnv so we don't rebuild every time.
+  if [ ! -x .direnv/devenv/bin/devenv ]; then
+    echo "direnv: devenv not found; bootstrapping via nixpkgs#devenv..." >&2
+    out="$(nix build --no-link --print-out-paths nixpkgs#devenv)"
+    ln -sfn "$out" .direnv/devenv
+  fi
+
+  PATH_add ".direnv/devenv/bin"
+fi
+
+# Now devenv exists, so this works reliably.
+eval "$(devenv direnvrc)"
 use devenv


### PR DESCRIPTION
- Automatically build and cache devenv using Nix if it's not found on the PATH.
- Caches the built binary in `.direnv/devenv` to avoid rebuilds.
- Provides a clear error message if neither `devenv` nor `nix` are available.