### PR TITLE
Remove explicit themesPath argument and fix config check

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,9 +53,6 @@
       # NixOS VM for testing
       nixosConfigurations.vogix16-test-vm = nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";
-        specialArgs = {
-          themesPath = ./themes;
-        };
         modules = [
           ./nix/vm/test-vm.nix
           self.nixosModules.default
@@ -75,9 +72,6 @@
             home-manager.useUserPackages = true;
             home-manager.users.vogix = import ./nix/vm/home.nix;
             home-manager.sharedModules = [ self.homeManagerModules.default ];
-            home-manager.extraSpecialArgs = {
-              themesPath = ./themes;
-            };
           }
         ];
       };

--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -1,7 +1,6 @@
 { config
 , lib
 , pkgs
-, themesPath ? null
 , ...
 }:
 
@@ -14,8 +13,7 @@ let
   vogix16 = pkgs.callPackage ../packages/vogix.nix { };
 
   # Auto-discover all theme files from themes directory
-  # Use provided themesPath or fall back to relative path
-  themesDir = if themesPath != null then themesPath else ../../themes;
+  themesDir = ../../themes;
   themeFiles = builtins.readDir themesDir;
   nixThemeFiles = builtins.filter (f: lib.hasSuffix ".nix" f) (builtins.attrNames themeFiles);
   autoDiscoveredThemes = lib.listToAttrs (
@@ -537,7 +535,7 @@ in
                                   ${pkgs.coreutils}/bin/mkdir -p "$CONFIG_DIR"
 
                                   # Check if target config file exists
-                                  if [[ ! -f "$CONFIG_TARGET" ]]; then
+                                  if [[ ! -r "$CONFIG_TARGET" ]]; then
                                     ${pkgs.coreutils}/bin/echo "    ERROR: Config target does not exist: $CONFIG_TARGET"
                                     exit 1
                                   fi

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, options, themesPath ? null, ... }:
+{ config, lib, pkgs, options, ... }:
 
 with lib;
 
@@ -80,7 +80,7 @@ in
             else null;
 
           # Get themes directory
-          themesDir = if themesPath != null then themesPath else ../../themes;
+          themesDir = ../../themes;
 
           # Get theme name and variant
           selectedThemeName = if hmVogixCfg != null then hmVogixCfg.defaultTheme else null;

--- a/nix/vm/test.nix
+++ b/nix/vm/test.nix
@@ -46,9 +46,6 @@ pkgs.testers.nixosTest {
         home-manager.nixosModules.home-manager
       ];
 
-      # Pass themesPath to both NixOS and home-manager modules
-      _module.args.themesPath = "${self}/themes";
-
       # Make vogix package available
       nixpkgs.overlays = [
         (final: prev: {
@@ -61,9 +58,6 @@ pkgs.testers.nixosTest {
       home-manager.useUserPackages = true;
       home-manager.users.vogix = import ./home.nix;
       home-manager.sharedModules = [ self.homeManagerModules.default ];
-      home-manager.extraSpecialArgs = {
-        themesPath = "${self}/themes";
-      };
     };
 
   testScript = ''


### PR DESCRIPTION
- Removed `themesPath` argument from NixOS and Home Manager modules to simplify configuration. The modules now reliably resolve the themes directory using relative paths (`../../themes`).
- Updated the config file existence check in `home-manager.nix` to use `[[ -r ... ]]` instead of `[[ -f ... ]]`. This ensures the script checks for read permissions, covering cases where the file exists but isn't readable.