### PR TITLE
Fix command injection vulnerability

### DIFF
--- a/src/reload.rs
+++ b/src/reload.rs
@@ -81,8 +81,11 @@ impl ReloadDispatcher {
             "touch" => {
                 // Touch the symlink itself (-h flag) to update its mtime
                 // Applications watching the file will detect the change
-                let cmd = format!("touch -h {}", metadata.config_path);
-                self.run_command(&cmd)?;
+                Command::new("touch")
+                    .arg("-h")
+                    .arg(&metadata.config_path)
+                    .status()
+                    .map_err(|e| crate::reload::VogixError::ReloadError(e.to_string()))?;
                 Ok("touched to trigger auto-reload".to_string())
             }
             "none" => Ok("no reload needed (changes take effect on next use)".to_string()),


### PR DESCRIPTION
Replace `sh -c "touch -h <path>"` with `std::process::Command` argument passing.
This prevents shell metacharacters in config_path from being interpreted as code
and avoids arbitrary command execution via crafted paths.