### PR TITLE
fix(deps): adopt praxis 0.25.4 — source WM-nav presets from praxis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,8 +1226,8 @@ dependencies = [
 
 [[package]]
 name = "pr4xis"
-version = "0.25.0"
-source = "git+https://github.com/i-am-logger/pr4xis.git?rev=e75053aa54913a660b6320216bfbae878078430e#e75053aa54913a660b6320216bfbae878078430e"
+version = "0.25.4"
+source = "git+https://github.com/i-am-logger/pr4xis.git?rev=b84ebab5a4c5f1e8e8558457d09ec1cbee623866#b84ebab5a4c5f1e8e8558457d09ec1cbee623866"
 dependencies = [
  "hashbrown",
  "linkme",
@@ -1240,8 +1240,8 @@ dependencies = [
 
 [[package]]
 name = "pr4xis-derive"
-version = "0.25.0"
-source = "git+https://github.com/i-am-logger/pr4xis.git?rev=e75053aa54913a660b6320216bfbae878078430e#e75053aa54913a660b6320216bfbae878078430e"
+version = "0.25.4"
+source = "git+https://github.com/i-am-logger/pr4xis.git?rev=b84ebab5a4c5f1e8e8558457d09ec1cbee623866#b84ebab5a4c5f1e8e8558457d09ec1cbee623866"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1251,8 +1251,8 @@ dependencies = [
 
 [[package]]
 name = "pr4xis-domains"
-version = "0.25.0"
-source = "git+https://github.com/i-am-logger/pr4xis.git?rev=e75053aa54913a660b6320216bfbae878078430e#e75053aa54913a660b6320216bfbae878078430e"
+version = "0.25.4"
+source = "git+https://github.com/i-am-logger/pr4xis.git?rev=b84ebab5a4c5f1e8e8558457d09ec1cbee623866#b84ebab5a4c5f1e8e8558457d09ec1cbee623866"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1272,8 +1272,8 @@ dependencies = [
 
 [[package]]
 name = "pr4xis-runtime"
-version = "0.25.0"
-source = "git+https://github.com/i-am-logger/pr4xis.git?rev=e75053aa54913a660b6320216bfbae878078430e#e75053aa54913a660b6320216bfbae878078430e"
+version = "0.25.4"
+source = "git+https://github.com/i-am-logger/pr4xis.git?rev=b84ebab5a4c5f1e8e8558457d09ec1cbee623866#b84ebab5a4c5f1e8e8558457d09ec1cbee623866"
 dependencies = [
  "blake3",
  "pr4xis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ thiserror = "2.0"
 # both from git. buildRustPackage vendors the git workspace (resolving
 # `version.workspace = true`), needing the outputHash in nix/packages/vogix.nix.
 # Bump the rev to advance.
-pr4xis = { git = "https://github.com/i-am-logger/pr4xis.git", rev = "e75053aa54913a660b6320216bfbae878078430e" }
-pr4xis-domains = { git = "https://github.com/i-am-logger/pr4xis.git", rev = "e75053aa54913a660b6320216bfbae878078430e" }
+pr4xis = { git = "https://github.com/i-am-logger/pr4xis.git", rev = "b84ebab5a4c5f1e8e8558457d09ec1cbee623866" }
+pr4xis-domains = { git = "https://github.com/i-am-logger/pr4xis.git", rev = "b84ebab5a4c5f1e8e8558457d09ec1cbee623866" }
 
 # Date/time for state timestamps
 chrono = "0.4"

--- a/nix/packages/vogix.nix
+++ b/nix/packages/vogix.nix
@@ -21,10 +21,10 @@ rustPlatform.buildRustPackage {
     # hash; cargo vendors the whole praxis workspace, so `version.workspace = true`
     # resolves against its root. All praxis crates share one git source ⇒ one hash.
     outputHashes = {
-      "pr4xis-0.25.0" = "sha256-9/FZp8lYXPjgOi2ek6I0DsujxVdv2spRx7iYIhY8qE8=";
-      "pr4xis-derive-0.25.0" = "sha256-9/FZp8lYXPjgOi2ek6I0DsujxVdv2spRx7iYIhY8qE8=";
-      "pr4xis-domains-0.25.0" = "sha256-9/FZp8lYXPjgOi2ek6I0DsujxVdv2spRx7iYIhY8qE8=";
-      "pr4xis-runtime-0.25.0" = "sha256-9/FZp8lYXPjgOi2ek6I0DsujxVdv2spRx7iYIhY8qE8=";
+      "pr4xis-0.25.4" = "sha256-6pmtkpKDnHh6jkygbvyGqi1xAjyy3t8KDKOmKc22JJU=";
+      "pr4xis-derive-0.25.4" = "sha256-6pmtkpKDnHh6jkygbvyGqi1xAjyy3t8KDKOmKc22JJU=";
+      "pr4xis-domains-0.25.4" = "sha256-6pmtkpKDnHh6jkygbvyGqi1xAjyy3t8KDKOmKc22JJU=";
+      "pr4xis-runtime-0.25.4" = "sha256-6pmtkpKDnHh6jkygbvyGqi1xAjyy3t8KDKOmKc22JJU=";
     };
   };
 

--- a/src/input/catalog.rs
+++ b/src/input/catalog.rs
@@ -1,10 +1,14 @@
-//! vogix-native interaction paradigms as praxis-shaped [`BindingSet`]s.
+//! Resolve a paradigm SELECTION into vogix's loaded-schema parts.
 //!
-//! These are the paradigms praxis does not ship a preset for: the desktop-chorded
-//! `windows` / `macos` / `linux`, and `vogix` (the house default = your live
-//! layout's WM-nav). They are authored here with the SAME praxis types as the
-//! consumed presets (`vim_preset()` etc.) so every paradigm projects uniformly
-//! ([`super::paradigm::project`]) and these can later move into praxis.
+//! Every WM-navigation paradigm is now sourced from a praxis preset —
+//! `vogix_preset()` / `windows_preset()` / `macos_preset()` / `linux_preset()`
+//! (the lift), plus `vim` / `cua` / `emacs` / `i3`: praxis is the single source of
+//! the bindings. This module pairs each praxis `BindingSet` with a small
+//! vogix-authored [`Topology`] (the root + per-mode parent/kind a flat preset
+//! can't express) and projects them into the `(modeGraph, modes)` the engine
+//! consumes ([`super::paradigm::project`]). The `*_nav_preset()` fns are thin
+//! aliases over the praxis presets, kept so the byte-identical guard still names
+//! them.
 //!
 //! Scope: a paradigm `BindingSet` is the WM-NAVIGATION flavour only (focus / move
 //! / resize / workspaces / window-state), over keys praxis's `Key` enum can
@@ -12,16 +16,14 @@
 //! can't represent (`super+slash`, `XF86Audio*`, `print`) — live in the vogix-side
 //! OVERLAY, layered on top of whichever paradigm is selected.
 use pr4xis_domains::applied::hmi::input::keybindings::{
-    Action, BindingSet, Key, KeyCombo, Modifier, cua_preset, emacs_preset, i3_preset, vim_preset,
+    BindingSet, cua_preset, emacs_preset, i3_preset, linux_preset, macos_preset, vim_preset,
+    vogix_preset, windows_preset,
 };
-use pr4xis_domains::applied::hmi::input::modes::ModeId;
 
 use std::collections::HashMap;
 
 use super::paradigm::{ModeTopo, Topology, project};
 use super::schema::{ModeGraphSpec, ModeSpec};
-
-use Modifier::{Alt, Ctrl, Shift, Super};
 
 /// Resolve a paradigm SELECTION name into its `(modeGraph, modes)` — the global
 /// interaction model the engine materializes. Every entry is SYSTEM-WIDE: select
@@ -35,15 +37,13 @@ use Modifier::{Alt, Ctrl, Shift, Super};
 /// engine only resolves when the schema omits its mode graph (the new format).
 pub fn resolve_paradigm(name: &str) -> Option<(ModeGraphSpec, HashMap<String, ModeSpec>)> {
     match name {
-        // vogix-authored: the house default (the user's live WM-nav layout).
+        // All paradigms are praxis-sourced, projected through a vogix-authored
+        // topology (the part a flat `BindingSet` can't express).
         "vogix" => Some(project(&vogix_nav_preset(), &VOGIX_TOPO)),
-        // praxis-sourced presets, projected through a vogix-authored topology.
         "i3" => Some(project(&i3_preset(), &I3_TOPO)),
         "cua" => Some(project(&cua_preset(), &CUA_TOPO)),
         "emacs" => Some(project(&emacs_preset(), &EMACS_TOPO)),
         "vim" => Some(project(&vim_preset(), &VIM_TOPO)),
-        // vogix-authored desktop paradigms (praxis has no preset yet — these are
-        // written in the praxis mold so they can move into praxis later).
         "windows" => Some(project(&windows_nav_preset(), &WINDOWS_TOPO)),
         "macos" => Some(project(&macos_nav_preset(), &MACOS_TOPO)),
         "linux" => Some(project(&linux_nav_preset(), &LINUX_TOPO)),
@@ -135,643 +135,31 @@ pub const LINUX_TOPO: Topology = Topology {
     modes: &[],
 };
 
-/// Build a [`KeyCombo`] from modifiers + a key.
-fn combo(mods: &[Modifier], key: Key) -> KeyCombo {
-    let mut c = KeyCombo::new(key);
-    for m in mods {
-        c = c.with_mod(*m);
-    }
-    c
-}
-
-/// The four cardinal directions as `(letter, arrow-name, hypr-suffix)`. The live
-/// layout binds BOTH `hjkl` and the arrows to the same action (`h`=left, `l`=right,
-/// `j`=up, `k`=down — the user's own non-vim mapping), so every nav verb is
-/// generated for both. Arrow names use praxis `NamedKey` (Left/Right/Up/Down).
-const DIRS: &[(char, NamedDir, &str)] = &[
-    ('h', NamedDir::Left, "l"),
-    ('l', NamedDir::Right, "r"),
-    ('j', NamedDir::Up, "u"),
-    ('k', NamedDir::Down, "d"),
-];
-
-#[derive(Clone, Copy)]
-enum NamedDir {
-    Left,
-    Right,
-    Up,
-    Down,
-}
-
-impl NamedDir {
-    fn key(self) -> Key {
-        use pr4xis_domains::applied::hmi::input::keybindings::NamedKey;
-        Key::Named(match self {
-            NamedDir::Left => NamedKey::Left,
-            NamedDir::Right => NamedKey::Right,
-            NamedDir::Up => NamedKey::Up,
-            NamedDir::Down => NamedKey::Down,
-        })
-    }
-}
-
-/// `vogix` — the house default: the user's live WM-navigation layout, flat
-/// `Super`-combos in one `app` mode. Byte-equivalent (by parsed chord+action) to
-/// the nav half of `nix/modules/behavior/defaults.nix`; the launch/system/media
-/// half is the overlay. Guarded by an equivalence test against the Nix output.
+/// `vogix` — the house default WM-navigation layout, sourced from praxis's
+/// `vogix_preset()` (the lift). This thin alias preserves the byte-identical guard
+/// against the deployed layout.
 pub fn vogix_nav_preset() -> BindingSet {
-    let mut bs = BindingSet::new("vogix");
-    let app = ModeId::new("app");
-    let mut add = |mods: &[Modifier], key: Key, name: &str, desc: &str, cmd: &str, repeat: bool| {
-        bs.add(
-            combo(mods, key),
-            app.clone(),
-            Action::new(name, desc, cmd),
-            repeat,
-        );
-    };
-
-    // ── Focus (Super + dir → movefocus); hjkl AND arrows ──
-    for (letter, arrow, suf) in DIRS {
-        let cmd = format!("movefocus, {suf}");
-        add(
-            &[Super],
-            Key::Letter(*letter),
-            &format!("focus_{suf}"),
-            "Focus",
-            &cmd,
-            false,
-        );
-        add(
-            &[Super],
-            arrow.key(),
-            &format!("focus_{suf}_arrow"),
-            "Focus",
-            &cmd,
-            false,
-        );
-    }
-    // ── Move window (Super + Shift + dir → swapwindow) ──
-    for (letter, arrow, suf) in DIRS {
-        let cmd = format!("swapwindow, {suf}");
-        add(
-            &[Super, Shift],
-            Key::Letter(*letter),
-            &format!("move_{suf}"),
-            "Move window",
-            &cmd,
-            false,
-        );
-        add(
-            &[Super, Shift],
-            arrow.key(),
-            &format!("move_{suf}_arrow"),
-            "Move window",
-            &cmd,
-            false,
-        );
-    }
-    // ── Resize window (Ctrl + Shift + dir → resizeactive; repeats) ──
-    let resize_deltas = [("l", "-30 0"), ("r", "30 0"), ("u", "0 -30"), ("d", "0 30")];
-    for (i, (letter, arrow, suf)) in DIRS.iter().enumerate() {
-        let cmd = format!("resizeactive, {}", resize_deltas[i].1);
-        add(
-            &[Ctrl, Shift],
-            Key::Letter(*letter),
-            &format!("resize_{suf}"),
-            "Resize",
-            &cmd,
-            true,
-        );
-        add(
-            &[Ctrl, Shift],
-            arrow.key(),
-            &format!("resize_{suf}_arrow"),
-            "Resize",
-            &cmd,
-            true,
-        );
-    }
-
-    // ── Window state (the yuiop row + q/tab) ──
-    add(
-        &[Super],
-        Key::Letter('q'),
-        "close",
-        "Close window",
-        "killactive,",
-        false,
-    );
-    add(
-        &[Super],
-        Key::Letter('y'),
-        "float_pin",
-        "Float + pin",
-        "exec, hyprctl dispatch togglefloating ; hyprctl dispatch pin",
-        false,
-    );
-    add(
-        &[Super],
-        Key::Letter('f'),
-        "fullscreen",
-        "Fullscreen",
-        "fullscreen",
-        false,
-    );
-    add(
-        &[Super],
-        Key::Letter('p'),
-        "pseudo",
-        "Pseudotile",
-        "pseudo,",
-        false,
-    );
-    add(
-        &[Super],
-        Key::Letter('o'),
-        "toggle_split",
-        "Toggle split",
-        "layoutmsg, togglesplit",
-        false,
-    );
-    add(
-        &[Super],
-        Key::Letter('u'),
-        "toggle_group",
-        "Toggle group",
-        "togglegroup,",
-        false,
-    );
-    {
-        use pr4xis_domains::applied::hmi::input::keybindings::NamedKey;
-        add(
-            &[Super],
-            Key::Named(NamedKey::Tab),
-            "group_cycle",
-            "Cycle window in group",
-            "changegroupactive, f",
-            false,
-        );
-    }
-
-    // ── Workspaces (Super + number; 0 = ws 10) ──
-    for n in 1u8..=10 {
-        let key = Key::Number(if n == 10 { 0 } else { n });
-        add(
-            &[Super],
-            key,
-            &format!("workspace_{n}"),
-            "Workspace",
-            &format!("workspace, {n}"),
-            false,
-        );
-    }
-    add(
-        &[Super],
-        Key::Letter('m'),
-        "workspace_music",
-        "Music workspace",
-        "workspace, Music",
-        false,
-    );
-
-    // ── Adjacent workspace (Super + Ctrl + ←/→ or j/l) ──
-    {
-        use pr4xis_domains::applied::hmi::input::keybindings::NamedKey;
-        add(
-            &[Super, Ctrl],
-            Key::Named(NamedKey::Left),
-            "ws_prev",
-            "Previous workspace",
-            "workspace, -1",
-            false,
-        );
-        add(
-            &[Super, Ctrl],
-            Key::Named(NamedKey::Right),
-            "ws_next",
-            "Next workspace",
-            "workspace, +1",
-            false,
-        );
-    }
-    add(
-        &[Super, Ctrl],
-        Key::Letter('j'),
-        "ws_prev_j",
-        "Previous workspace",
-        "workspace, -1",
-        false,
-    );
-    add(
-        &[Super, Ctrl],
-        Key::Letter('l'),
-        "ws_next_l",
-        "Next workspace",
-        "workspace, +1",
-        false,
-    );
-
-    // ── Send window to workspace (Super + Ctrl + number) ──
-    for n in 1u8..=10 {
-        let key = Key::Number(if n == 10 { 0 } else { n });
-        add(
-            &[Super, Ctrl],
-            key,
-            &format!("move_to_ws_{n}"),
-            "Send window to workspace",
-            &format!("movetoworkspace, {n}"),
-            false,
-        );
-    }
-    // ── Send window to adjacent workspace (Super + Ctrl + Shift + ←/→ or j/l) ──
-    {
-        use pr4xis_domains::applied::hmi::input::keybindings::NamedKey;
-        add(
-            &[Super, Ctrl, Shift],
-            Key::Named(NamedKey::Left),
-            "send_ws_prev",
-            "Send window ← workspace",
-            "movetoworkspace, -1",
-            false,
-        );
-        add(
-            &[Super, Ctrl, Shift],
-            Key::Named(NamedKey::Right),
-            "send_ws_next",
-            "Send window → workspace",
-            "movetoworkspace, +1",
-            false,
-        );
-    }
-    add(
-        &[Super, Ctrl, Shift],
-        Key::Letter('j'),
-        "send_ws_prev_j",
-        "Send window ← workspace",
-        "movetoworkspace, -1",
-        false,
-    );
-    add(
-        &[Super, Ctrl, Shift],
-        Key::Letter('l'),
-        "send_ws_next_l",
-        "Send window → workspace",
-        "movetoworkspace, +1",
-        false,
-    );
-
-    // ── Send window to workspace silently (Super + Shift + number) ──
-    for n in 1u8..=10 {
-        let key = Key::Number(if n == 10 { 0 } else { n });
-        add(
-            &[Super, Shift],
-            key,
-            &format!("move_silent_{n}"),
-            "Send window to workspace (silent)",
-            &format!("movetoworkspacesilent, {n}"),
-            false,
-        );
-    }
-
-    bs
+    vogix_preset()
 }
 
-/// `windows` — Microsoft Windows 11 global window & virtual-desktop keyboard
-/// conventions, projected to Hyprland. Single passthrough `app` mode, NO remap
-/// (Windows uses Ctrl natively for the clipboard). Hyprland has no snap / maximize
-/// / minimize, so those conventions are ADAPTED to the nearest real dispatcher
-/// (snap → directional `movewindow`, maximize → `fullscreen`); Win+D / Win+M /
-/// Win+Tab are omitted (no Hyprland show-desktop / minimize / overview). Win+1..9
-/// (natively a taskbar-app launcher) is treated as virtual-desktop N.
-///
-/// Source: Microsoft Support, "Keyboard shortcuts in Windows".
+/// `windows` — Microsoft Windows global window conventions, sourced from praxis's
+/// `windows_preset()`. Win+Up maximize realizes to `fullscreen, 1` (the maximize
+/// state), distinct from true fullscreen.
 pub fn windows_nav_preset() -> BindingSet {
-    use pr4xis_domains::applied::hmi::input::keybindings::NamedKey;
-    let mut bs = BindingSet::new("windows");
-    let app = ModeId::new("app");
-    let mut add = |mods: &[Modifier], key: Key, name: &str, desc: &str, cmd: &str| {
-        bs.add(
-            combo(mods, key),
-            app.clone(),
-            Action::new(name, desc, cmd),
-            false,
-        );
-    };
-
-    // Window switch (Alt+Tab) + close (Alt+F4) — faithful.
-    add(
-        &[Alt],
-        Key::Named(NamedKey::Tab),
-        "switch_window",
-        "Switch window",
-        "cyclenext,",
-    );
-    add(
-        &[Alt, Shift],
-        Key::Named(NamedKey::Tab),
-        "switch_window_prev",
-        "Switch window (reverse)",
-        "cyclenext, prev",
-    );
-    add(
-        &[Alt],
-        Key::Function(4),
-        "close",
-        "Close window",
-        "killactive,",
-    );
-
-    // Snap (Win+←/→) + maximize (Win+↑) — adapted (no snap/maximize in Hyprland).
-    add(
-        &[Super],
-        Key::Named(NamedKey::Left),
-        "snap_left",
-        "Snap window left",
-        "movewindow, l",
-    );
-    add(
-        &[Super],
-        Key::Named(NamedKey::Right),
-        "snap_right",
-        "Snap window right",
-        "movewindow, r",
-    );
-    add(
-        &[Super],
-        Key::Named(NamedKey::Up),
-        "maximize",
-        "Maximize window",
-        "fullscreen",
-    );
-
-    // Move window (Win+Shift+arrows: monitor/stretch/restore) — adapted to a
-    // directional move (Hyprland has no monitor-move / vertical-stretch / restore).
-    add(
-        &[Super, Shift],
-        Key::Named(NamedKey::Left),
-        "move_left",
-        "Move window left",
-        "movewindow, l",
-    );
-    add(
-        &[Super, Shift],
-        Key::Named(NamedKey::Right),
-        "move_right",
-        "Move window right",
-        "movewindow, r",
-    );
-    add(
-        &[Super, Shift],
-        Key::Named(NamedKey::Up),
-        "move_up",
-        "Move window up",
-        "movewindow, u",
-    );
-    add(
-        &[Super, Shift],
-        Key::Named(NamedKey::Down),
-        "move_down",
-        "Move window down",
-        "movewindow, d",
-    );
-
-    // Virtual desktops: Ctrl+Win+←/→ switch; Win+1..9 → desktop N.
-    add(
-        &[Super, Ctrl],
-        Key::Named(NamedKey::Left),
-        "desktop_prev",
-        "Previous virtual desktop",
-        "workspace, -1",
-    );
-    add(
-        &[Super, Ctrl],
-        Key::Named(NamedKey::Right),
-        "desktop_next",
-        "Next virtual desktop",
-        "workspace, +1",
-    );
-    for n in 1u8..=9 {
-        add(
-            &[Super],
-            Key::Number(n),
-            &format!("workspace_{n}"),
-            "Virtual desktop",
-            &format!("workspace, {n}"),
-        );
-    }
-    bs
+    windows_preset()
 }
 
-/// `macos` — Apple macOS global Mission Control / Spaces / window conventions,
-/// projected to Hyprland. Pairs with the `macos` remap (the Cmd-feel: Super+letter
-/// → Ctrl+letter) for app shortcuts; the window verbs here (Cmd+W/Q/H/M) are
-/// BOUND, so they take precedence over the remap for those letters (bindings win —
-/// see `device.rs`), while the rest of Cmd+letter remaps to Ctrl. Spaces / Mission
-/// Control are natively Ctrl-based (not remapped), and Cmd+Tab uses NamedKey Tab
-/// (also untouched). Hyprland has no Mission Control / hide / minimize, so those
-/// are ADAPTED (overview / hidden+minimized special workspaces).
-///
-/// Source: Apple Support, "Mac keyboard shortcuts" & "Use Mission Control".
+/// `macos` — Apple macOS Mission Control / Spaces / window conventions, sourced
+/// from praxis's `macos_preset()` (pairs with the `macos` Cmd-feel remap; hide /
+/// minimize are silent moves to special workspaces).
 pub fn macos_nav_preset() -> BindingSet {
-    use pr4xis_domains::applied::hmi::input::keybindings::NamedKey;
-    let mut bs = BindingSet::new("macos");
-    let app = ModeId::new("app");
-    let mut add = |mods: &[Modifier], key: Key, name: &str, desc: &str, cmd: &str| {
-        bs.add(
-            combo(mods, key),
-            app.clone(),
-            Action::new(name, desc, cmd),
-            false,
-        );
-    };
-
-    // Spaces: Ctrl+←/→ + Ctrl+1..9 (native Ctrl — untouched by the Cmd remap).
-    add(
-        &[Ctrl],
-        Key::Named(NamedKey::Left),
-        "workspace_prev",
-        "Previous Space",
-        "workspace, -1",
-    );
-    add(
-        &[Ctrl],
-        Key::Named(NamedKey::Right),
-        "workspace_next",
-        "Next Space",
-        "workspace, +1",
-    );
-    for n in 1u8..=9 {
-        add(
-            &[Ctrl],
-            Key::Number(n),
-            &format!("workspace_{n}"),
-            "Space",
-            &format!("workspace, {n}"),
-        );
-    }
-    // Mission Control (Ctrl+↑) — adapted to an `overview` special workspace.
-    add(
-        &[Ctrl],
-        Key::Named(NamedKey::Up),
-        "mission_control",
-        "Mission Control",
-        "togglespecialworkspace, overview",
-    );
-
-    // Window switch (Cmd+Tab) — Tab is not a letter, so not remapped.
-    add(
-        &[Super],
-        Key::Named(NamedKey::Tab),
-        "switch_window",
-        "Switch window",
-        "cyclenext,",
-    );
-    add(
-        &[Super, Shift],
-        Key::Named(NamedKey::Tab),
-        "switch_window_prev",
-        "Switch window (reverse)",
-        "cyclenext, prev",
-    );
-
-    // Window verbs (Cmd+W/Q/H/M) — bound, so they win over the remap for w/q/h/m.
-    add(
-        &[Super],
-        Key::Letter('w'),
-        "close_window",
-        "Close window",
-        "killactive,",
-    );
-    add(
-        &[Super],
-        Key::Letter('q'),
-        "quit",
-        "Quit app",
-        "killactive,",
-    );
-    add(
-        &[Super],
-        Key::Letter('h'),
-        "hide",
-        "Hide window",
-        "movetoworkspacesilent, special:hidden",
-    );
-    add(
-        &[Super],
-        Key::Letter('m'),
-        "minimize",
-        "Minimize window",
-        "movetoworkspacesilent, special:minimized",
-    );
-    // Fullscreen (Ctrl+Cmd+F) — two modifiers, so not remapped.
-    add(
-        &[Ctrl, Super],
-        Key::Letter('f'),
-        "fullscreen",
-        "Toggle fullscreen",
-        "fullscreen",
-    );
-    bs
+    macos_preset()
 }
 
-/// `linux` — mainstream GNOME Shell global window conventions, projected to
-/// Hyprland. Single passthrough `app` mode, NO remap (native Ctrl). The faithful
-/// workspace verbs are the relative Super+PageUp/PageDown pair; GNOME's per-index
-/// Super+1..9 is app-LAUNCH (`switch-to-application-N`), NOT workspace switching,
-/// so it is deliberately omitted (it would belong in the user's overlay). Hyprland
-/// has no snap / maximize / minimize, so tile / maximize / hide are ADAPTED.
-///
-/// Source: GNOME Shell defaults (`org.gnome.desktop.wm.keybindings`).
+/// `linux` — mainstream GNOME Shell global window conventions, sourced from
+/// praxis's `linux_preset()`. Super+Up maximize realizes to `fullscreen, 1`.
 pub fn linux_nav_preset() -> BindingSet {
-    use pr4xis_domains::applied::hmi::input::keybindings::NamedKey;
-    let mut bs = BindingSet::new("linux");
-    let app = ModeId::new("app");
-    let mut add = |mods: &[Modifier], key: Key, name: &str, desc: &str, cmd: &str| {
-        bs.add(
-            combo(mods, key),
-            app.clone(),
-            Action::new(name, desc, cmd),
-            false,
-        );
-    };
-
-    // Workspaces: Super+PageUp/PageDown switch; Super+Shift+PageUp/Down move window.
-    add(
-        &[Super],
-        Key::Named(NamedKey::PageUp),
-        "workspace_prev",
-        "Previous workspace",
-        "workspace, -1",
-    );
-    add(
-        &[Super],
-        Key::Named(NamedKey::PageDown),
-        "workspace_next",
-        "Next workspace",
-        "workspace, +1",
-    );
-    add(
-        &[Super, Shift],
-        Key::Named(NamedKey::PageUp),
-        "move_to_prev",
-        "Move window ← workspace",
-        "movetoworkspace, -1",
-    );
-    add(
-        &[Super, Shift],
-        Key::Named(NamedKey::PageDown),
-        "move_to_next",
-        "Move window → workspace",
-        "movetoworkspace, +1",
-    );
-
-    // Window switch (Alt+Tab) + close (Alt+F4) — faithful.
-    add(
-        &[Alt],
-        Key::Named(NamedKey::Tab),
-        "switch_window",
-        "Switch window",
-        "cyclenext,",
-    );
-    add(
-        &[Alt],
-        Key::Function(4),
-        "kill",
-        "Close window",
-        "killactive,",
-    );
-
-    // Maximize (Super+↑ → fullscreen) + tile (Super+←/→) + hide (Super+H) — adapted.
-    add(
-        &[Super],
-        Key::Named(NamedKey::Up),
-        "fullscreen",
-        "Maximize window",
-        "fullscreen",
-    );
-    add(
-        &[Super],
-        Key::Named(NamedKey::Left),
-        "tile_left",
-        "Tile window left",
-        "movewindow, l",
-    );
-    add(
-        &[Super],
-        Key::Named(NamedKey::Right),
-        "tile_right",
-        "Tile window right",
-        "movewindow, r",
-    );
-    add(
-        &[Super],
-        Key::Letter('h'),
-        "hide",
-        "Hide window",
-        "movetoworkspacesilent, special",
-    );
-    bs
+    linux_preset()
 }
 
 #[cfg(test)]
@@ -1067,7 +455,7 @@ mod tests {
         assert_eq!(app.bindings["switch_window"].action, "cyclenext,");
         assert_eq!(app.bindings["close"].action, "killactive,");
         assert_eq!(app.bindings["snap_left"].action, "movewindow, l");
-        assert_eq!(app.bindings["maximize"].action, "fullscreen");
+        assert_eq!(app.bindings["maximize"].action, "fullscreen, 1");
         assert_eq!(app.bindings["desktop_next"].action, "workspace, +1");
         assert_eq!(app.bindings["workspace_1"].action, "workspace, 1");
         // WM-nav only — no app-launch leaked into the paradigm.

--- a/src/input/paradigm.rs
+++ b/src/input/paradigm.rs
@@ -110,7 +110,7 @@ pub fn project(bs: &BindingSet, topo: &Topology) -> (ModeGraphSpec, HashMap<Stri
     for b in &bs.bindings {
         let binding = Binding {
             key: render_combo(&b.combo),
-            action: b.action.command.clone(),
+            action: b.action.command(),
             exit_after: false,
             repeat: b.repeat,
             description: Some(b.action.description.clone()),


### PR DESCRIPTION
Adopts **praxis 0.25.4** (the `WmAction` ontology) and completes the #13 lift on the vogix side: vogix now **consumes** the praxis WM-nav presets instead of carrying native duplicates.

## What
- praxis 0.25.4 ships `WmAction` — the typed window-action ontology lifted from vogix's own input catalog (intent / parameters / mechanism, realized by a functor).
- vogix's `catalog.rs` now calls praxis's `vogix_preset` / `windows_preset` / `macos_preset` / `linux_preset`; the four `*_nav_preset()` fns are thin aliases. ~600 lines of duplicated `BindingSet` code removed.
- `paradigm.rs` projects via `Action::command()` (the realization functor) instead of the removed `Action.command` field.

## Behaviour: unchanged
Byte-identical to the deployed layout — guarded by `vogix_nav_is_byte_identical_to_live_layout` (praxis `vogix_preset` == the live fixture) plus the per-paradigm projection tests.

## Mechanics
- `Cargo.toml`: bump `pr4xis` + `pr4xis-domains` git rev to praxis 0.25.4 (`b84ebab5`).
- `nix/packages/vogix.nix`: recompute the cargoLock `outputHashes` for 0.25.4.

## Verification
320 tests + clippy `-D warnings` + `nix build .#vogix` + `nix flake check` all green.
