### PR TITLE
feat(deps): update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -23,7 +23,7 @@ jobs:
       )
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
@@ -57,7 +57,7 @@ jobs:
     needs: devenv-checks
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
@@ -106,7 +106,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           config-file: .release-please-config.json


### PR DESCRIPTION
Bumps GitHub Actions to their latest releases.

| action | old → new |
|---|---|
| actions/checkout | v4 → v7 |
| googleapis/release-please-action | v4 → v5 |

release-please-action v5's only breaking change is the node24 runtime — config/inputs/behaviour unchanged. `DeterminateSystems/nix-installer-action@main` (rolling) left untouched. `actionlint` clean.