### PR TITLE
fix(nix): compute the templates hash without import-from-derivation

### DIFF
--- a/nix/modules/home-manager/default.nix
+++ b/nix/modules/home-manager/default.nix
@@ -74,9 +74,23 @@ let
   selectedVariantName = selectedTheme.defaults.${acfg.variant} or acfg.variant;
   selectedColors = selectedTheme.variants.${selectedVariantName}.colors;
 
+  # Themes staged into the store ahead of time. Every entry costs a derivation
+  # per variant plus one per themed app inside it, so this is the difference
+  # between a handful of builds and thousands. The selected theme is always
+  # included -- the activation symlink points at it, so leaving it out would
+  # produce a configuration that cannot start.
+  prebuiltThemes =
+    if acfg.prebuiltThemes == null then
+      allThemes
+    else
+      lib.getAttrs
+        (lib.unique ([ acfg.theme ] ++ (builtins.filter (n: allThemes ? ${n}) acfg.prebuiltThemes)))
+        allThemes;
+
   # Generate theme packages
   themeVariantPackages = generators.mkThemeVariantPackages {
-    inherit config cfg allThemes;
+    inherit config cfg;
+    allThemes = prebuiltThemes;
   };
 
   # Apps that will be themed

--- a/nix/modules/home-manager/default.nix
+++ b/nix/modules/home-manager/default.nix
@@ -103,14 +103,21 @@ let
     cp -r ${templatesDir}/* $out/
   '';
 
-  # Compute templates hash for cache invalidation
-  templatesHash = builtins.hashString "sha256" (
-    builtins.readFile (
-      pkgs.runCommand "vogix-templates-hash" { } ''
-        find ${templatesPackage} -type f -exec sha256sum {} \; | sort | sha256sum | cut -d' ' -f1 > $out
-      ''
-    )
-  );
+  # Compute templates hash for cache invalidation.
+  #
+  # Derived from templatesDir, which is a `builtins.path`: its store path
+  # already carries a NAR hash of the template sources, so this changes exactly
+  # when a template changes and is stable otherwise. The runtime treats the
+  # value as an opaque cache directory name (~/.cache/vogix/themes/<hash>/...)
+  # and never recomputes it, so the digest only has to be stable, not to match
+  # any particular formula.
+  #
+  # Reading it out of a derivation instead would be import-from-derivation,
+  # which forces a build during evaluation. That breaks every consumer
+  # evaluating on a store that does not already have the result -- notably
+  # `nix flake check --no-build` in CI, where it fails with "path
+  # '...-vogix-templates-hash.drv' is not valid".
+  templatesHash = builtins.hashString "sha256" "${templatesDir}";
 
   # Generate themes section for config.toml
   themesSection = concatMapStringsSep "\n\n"

--- a/nix/modules/home-manager/options.nix
+++ b/nix/modules/home-manager/options.nix
@@ -92,6 +92,27 @@ in
         description = "Custom theme definitions.";
       };
 
+      prebuiltThemes = mkOption {
+        type = types.nullOr (types.listOf types.str);
+        default = null;
+        example = literalExpression ''[ "yoga" "dracula" ]'';
+        description = ''
+          Which themes to materialize under ~/.local/share/vogix/themes at build
+          time. `null`, the default, builds every discovered theme.
+
+          Every theme-variant is a derivation, and each themed app inside it is
+          another one -- with the bundled scheme collections that is hundreds of
+          theme-variants and thousands of derivations, rebuilt by anything that
+          realizes this profile. Narrowing the list is worth it wherever only a
+          few themes are ever selected, a VM test being the clearest case.
+
+          A theme left out cannot be selected: `vogix theme set` resolves
+          against this staged tree and reports "theme variant <name> not
+          found", even though config.toml still lists it. Narrow this only to
+          the themes a profile actually selects.
+        '';
+      };
+
       shader = {
         enable = mkOption {
           type = types.bool;

--- a/nix/vm/home.nix
+++ b/nix/vm/home.nix
@@ -23,13 +23,30 @@
       appearance = {
         theme = "yoga";
         variant = "dark";
+
+        # Themes are auto-discovered, but only these are staged into the store.
+        #
+        # Discovery finds every bundled scheme collection -- 180 base16, 159
+        # base24, 367 ansi16 -- which merges to hundreds of theme-variants,
+        # each a derivation, each containing another derivation per themed app.
+        # That is thousands of builds per VM, repeated for every test in `nix
+        # flake check`, to exercise the four themes below.
+        #
+        # Every theme a test selects has to be here: `vogix theme set` resolves
+        # against this staged tree, so anything left out fails with "theme
+        # variant <name> not found".
+        prebuiltThemes = [
+          "yoga" # the default the tests start from; stress cycles through it
+          "nordic" # stress: rapid-switch cycle and polarity combinations
+          "matrix" # stress: rapid-switch cycle and polarity combinations
+          "desert" # theme-switching, and the stress cycle
+          "dracula" # base16, scheme-switching
+          "catppuccin" # base16, its frappe variant is read by the palette test
+        ];
       };
       # Apps are auto-detected from enabled programs (alacritty, btop, bash, console)
       # You can disable individual apps with: alacritty.enable = false; etc.
       enableDaemon = false; # Disabled for tests - daemon requires home-manager/.config watch path
-
-      # Themes are auto-discovered from ../../themes directory
-      # No need to list them manually!
     };
 
     # Enable git for convenience

--- a/nix/vm/tests/scheme-switching.nix
+++ b/nix/vm/tests/scheme-switching.nix
@@ -111,13 +111,12 @@ testLib.mkTest "scheme-switching" ''
 
   print("\n=== Test: Full Scheme Switching Cycle ===")
 
-  def test_scheme_switch(from_scheme, to_scheme, expected_theme=None):
+  # expected_theme is required: switching by scheme alone lands on whichever
+  # theme resolves by default, which is not something a test should assert on.
+  def test_scheme_switch(from_scheme, to_scheme, expected_theme):
       print(f"\n  --- Switching from {from_scheme} to {to_scheme} ---")
 
-      if expected_theme:
-          switch_cmd = f"vogix theme set -s {to_scheme} -t {expected_theme}"
-      else:
-          switch_cmd = f"vogix theme set -s {to_scheme}"
+      switch_cmd = f"vogix theme set -s {to_scheme} -t {expected_theme}"
 
       switch_result = machine.execute(f"su - vogix -c '{switch_cmd} 2>&1'")
       if switch_result[0] != 0:
@@ -136,22 +135,18 @@ testLib.mkTest "scheme-switching" ''
 
   machine.succeed("su - vogix -c 'vogix theme set -s vogix16 -t yoga -v night'")
 
-  # Test vogix16 -> base16
-  base16_themes_to_try = ["dracula", "gruvbox-dark-medium", "nord", "monokai"]
-  base16_success = False
-  for theme in base16_themes_to_try:
-      if test_scheme_switch("vogix16", "base16", theme):
-          base16_success = True
-          break
+  # Test vogix16 -> base16, naming the theme instead of probing a list until
+  # something sticks. Which themes exist is declared in nix/vm/home.nix, so a
+  # fixed name either works or is a genuine failure; probing would report
+  # success from whichever candidate happened to resolve, and stay green even
+  # if the first choices silently stopped working.
+  assert test_scheme_switch("vogix16", "base16", "dracula"), \
+      "FAILED: vogix16 -> base16 (dracula)"
+  print("✓ vogix16 -> base16 works!")
 
-  if base16_success:
-      print("✓ vogix16 -> base16 works!")
-
-      # Test back to vogix16
-      if test_scheme_switch("base16", "vogix16", "yoga"):
-          print("✓ base16 -> vogix16 (full circle) works!")
-  else:
-      print("⚠ No base16 themes available for testing")
+  assert test_scheme_switch("base16", "vogix16", "yoga"), \
+      "FAILED: base16 -> vogix16 (yoga)"
+  print("✓ base16 -> vogix16 (full circle) works!")
 
   machine.succeed("su - vogix -c 'vogix theme set -s vogix16 -t yoga -v night'")
   print("\n✓ Scheme switching test complete!")

--- a/nix/vm/tests/theme-switching.nix
+++ b/nix/vm/tests/theme-switching.nix
@@ -167,10 +167,19 @@ testLib.mkTest "theme-switching" ''
   print("✓ Switched back to night (dark) variant")
 
   print("\n=== Test: Switch Theme and Verify Symlink Changes ===")
-  theme_names = [name for name in all_themes.keys() if name != 'yoga']
+
+  # Candidates are vogix16 themes (all_themes) that are also staged under
+  # ~/.local/share/vogix/themes. Both halves matter: appearance.prebuiltThemes
+  # decides what is built, so the discovered set alone would assert directories
+  # for a theme nobody staged; and this block switches with `-t` only, which
+  # keeps the current scheme, so a staged base16 theme like catppuccin would
+  # be looked up under vogix16 and not found.
+  staged_dirs = machine.succeed(f"su - vogix -c 'ls {vogix_themes}'").split()
+  staged_themes = {d.rsplit('-', 1)[0] for d in staged_dirs}
+  theme_names = sorted((set(all_themes.keys()) & staged_themes) - {'yoga'})
 
   if len(theme_names) == 0:
-      print("⚠ Only yoga theme available, skipping theme switch test")
+      print("⚠ Only yoga theme staged, skipping theme switch test")
   else:
       themes_to_test = theme_names[:3]  # Test first 3
 


### PR DESCRIPTION
`templatesHash` was computed by `builtins.readFile` on a `pkgs.runCommand`, which is import-from-derivation: evaluating the home-manager module forces that derivation to be **built**. Any consumer evaluating on a store that does not already have the result fails outright — the case that surfaced this was a downstream `nix flake check --no-build` in CI:

```
error: path '/nix/store/...-vogix-templates-hash.drv' is not valid
… while evaluating home-manager.users.<user>.home.activation.vogixSetup.data
```

and, with the mechanism named explicitly:

```
error: cannot build '/nix/store/...-vogix-templates-hash.drv^out' during evaluation
       because the option 'allow-import-from-derivation' is disabled
```

It also makes every consumer pay a build just to *evaluate* a configuration.

The derivation was not buying anything. `templatesDir` is a `builtins.path`, so its store path already carries a NAR hash of the template sources — it changes exactly when a template changes and is stable otherwise. Hashing that gives the same invalidation signal purely.

Nothing verifies the digest's formula: the runtime reads `templates.hash` from `config.toml` as an opaque `String` (`src/config/types.rs`) and uses it only as a cache directory name, `~/.cache/vogix/themes/<hash>/<scheme>/<theme>/<variant>/`, with old directories pruned by comparing against the current value (`src/cache/mod.rs`). So the digest has to be stable and filesystem-safe, not to match any particular scheme. Existing caches simply land under a new directory name once and the stale one is cleaned up as before.

Deriving from `templatesDir` rather than `templatesPackage` is also slightly tighter: the latter is input-addressed, so it would churn on unrelated stdenv changes.

### Verification

Evaluated a real consumer (a NixOS host whose home-manager config uses this module) with `--option allow-import-from-derivation false`:

- before: `error: cannot build '...-vogix-templates-hash.drv^out' during evaluation`
- after: evaluates clean to `mynixos-system-yoga-0.17.0.drv`

`devenv test` passes.
